### PR TITLE
Enable multi-platform builds for Docker

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.server
+          platforms: linux/amd64,linux/arm64
           # Only push if not a pull request
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-server.outputs.tags }}


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
Configure the Docker workflow to support building images for both amd64 and arm64 platforms.
