### PR TITLE
feat: Add bi-directional relationship view

### DIFF
--- a/client/src/client/schema.d.ts
+++ b/client/src/client/schema.d.ts
@@ -22,8 +22,6 @@ export interface paths {
          *     - `github.com/go-fuego/fuego.defaultLogger.middleware`
          *
          *     ---
-         *
-         *
          */
         get: operations["GET_/api/v1/health"];
         put?: never;
@@ -774,7 +772,7 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
-        /** @description  schema */
+        /** @description schema */
         "": unknown;
         /** @description CreateIdentificationHelperDTO schema */
         CreateIdentificationHelperDTO: {
@@ -789,10 +787,7 @@ export interface components {
         CreateProductDTO: {
             /** @example Product Description */
             description?: string;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
             family_id?: string | null;
             /** @example Product Name */
             name: string;
@@ -805,25 +800,16 @@ export interface components {
         CreateProductFamilyDTO: {
             /** @example Family Name */
             name: string;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
-            parent_id?: string;
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
+            parent_id?: string | null;
         };
         /** @description CreateProductVersionDTO schema */
         CreateProductVersionDTO: {
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
             predecessor_id?: string | null;
             /** @example 123e4567-e89b-12d3-a456-426614174000 */
             product_id: string;
-            /**
-             * @description string schema
-             * @example 2023-10-01
-             */
+            /** @example 2023-10-01 */
             release_date?: string | null;
             /** @example Version Name */
             version: string;
@@ -851,7 +837,7 @@ export interface components {
         HTTPError: {
             /** @description Human readable error message */
             detail?: string | null;
-            errors?: {
+            errors?: ({
                 /** @description Additional information about the error */
                 more?: {
                     [key: string]: unknown;
@@ -860,7 +846,7 @@ export interface components {
                 name?: string;
                 /** @description Human readable error message */
                 reason?: string;
-            }[] | null;
+            } | null)[] | null;
             instance?: string | null;
             /**
              * @description HTTP status code
@@ -898,10 +884,7 @@ export interface components {
         ProductDTO: {
             /** @example Product Description */
             description?: string;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
             family_id?: string | null;
             /** @example Vendor Name - Product Name */
             full_name: string;
@@ -918,31 +901,19 @@ export interface components {
                 is_latest: boolean;
                 /** @example Version Name */
                 name: string;
-                /**
-                 * @description string schema
-                 * @example 123e4567-e89b-12d3-a456-426614174000
-                 */
+                /** @example 123e4567-e89b-12d3-a456-426614174000 */
                 predecessor_id?: string | null;
-                /**
-                 * @description string schema
-                 * @example 123e4567-e89b-12d3-a456-426614174000
-                 */
-                product_id?: string;
-                /**
-                 * @description string schema
-                 * @example 2023-10-01
-                 */
+                /** @example 123e4567-e89b-12d3-a456-426614174000 */
+                product_id?: string | null;
+                /** @example 2023-10-01 */
                 released_at?: string | null;
             }[];
             /** @example Product Name */
             name: string;
             /** @example software */
             type: string;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
-            vendor_id?: string;
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
+            vendor_id?: string | null;
             versions?: {
                 /** @example Version Description */
                 description?: string;
@@ -954,20 +925,11 @@ export interface components {
                 is_latest: boolean;
                 /** @example Version Name */
                 name: string;
-                /**
-                 * @description string schema
-                 * @example 123e4567-e89b-12d3-a456-426614174000
-                 */
+                /** @example 123e4567-e89b-12d3-a456-426614174000 */
                 predecessor_id?: string | null;
-                /**
-                 * @description string schema
-                 * @example 123e4567-e89b-12d3-a456-426614174000
-                 */
-                product_id?: string;
-                /**
-                 * @description string schema
-                 * @example 2023-10-01
-                 */
+                /** @example 123e4567-e89b-12d3-a456-426614174000 */
+                product_id?: string | null;
+                /** @example 2023-10-01 */
                 released_at?: string | null;
             }[];
         };
@@ -977,11 +939,8 @@ export interface components {
             id: string;
             /** @example Family Name */
             name: string;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
-            parent_id?: string;
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
+            parent_id?: string | null;
             /** @example ['Parent Family', 'Family Name'] */
             path: string[];
         };
@@ -997,20 +956,11 @@ export interface components {
             is_latest: boolean;
             /** @example Version Name */
             name: string;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
             predecessor_id?: string | null;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
-            product_id?: string;
-            /**
-             * @description string schema
-             * @example 2023-10-01
-             */
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
+            product_id?: string | null;
+            /** @example 2023-10-01 */
             released_at?: string | null;
         };
         /** @description RelationshipDTO schema */
@@ -1030,20 +980,11 @@ export interface components {
                 is_latest: boolean;
                 /** @example Version Name */
                 name: string;
-                /**
-                 * @description string schema
-                 * @example 123e4567-e89b-12d3-a456-426614174000
-                 */
+                /** @example 123e4567-e89b-12d3-a456-426614174000 */
                 predecessor_id?: string | null;
-                /**
-                 * @description string schema
-                 * @example 123e4567-e89b-12d3-a456-426614174000
-                 */
-                product_id?: string;
-                /**
-                 * @description string schema
-                 * @example 2023-10-01
-                 */
+                /** @example 123e4567-e89b-12d3-a456-426614174000 */
+                product_id?: string | null;
+                /** @example 2023-10-01 */
                 released_at?: string | null;
             };
             target: {
@@ -1057,20 +998,11 @@ export interface components {
                 is_latest: boolean;
                 /** @example Version Name */
                 name: string;
-                /**
-                 * @description string schema
-                 * @example 123e4567-e89b-12d3-a456-426614174000
-                 */
+                /** @example 123e4567-e89b-12d3-a456-426614174000 */
                 predecessor_id?: string | null;
-                /**
-                 * @description string schema
-                 * @example 123e4567-e89b-12d3-a456-426614174000
-                 */
-                product_id?: string;
-                /**
-                 * @description string schema
-                 * @example 2023-10-01
-                 */
+                /** @example 123e4567-e89b-12d3-a456-426614174000 */
+                product_id?: string | null;
+                /** @example 2023-10-01 */
                 released_at?: string | null;
             };
         };
@@ -1082,10 +1014,7 @@ export interface components {
                 product: {
                     /** @example Product Description */
                     description?: string;
-                    /**
-                     * @description string schema
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
+                    /** @example 123e4567-e89b-12d3-a456-426614174000 */
                     family_id?: string | null;
                     /** @example Vendor Name - Product Name */
                     full_name: string;
@@ -1102,31 +1031,19 @@ export interface components {
                         is_latest: boolean;
                         /** @example Version Name */
                         name: string;
-                        /**
-                         * @description string schema
-                         * @example 123e4567-e89b-12d3-a456-426614174000
-                         */
+                        /** @example 123e4567-e89b-12d3-a456-426614174000 */
                         predecessor_id?: string | null;
-                        /**
-                         * @description string schema
-                         * @example 123e4567-e89b-12d3-a456-426614174000
-                         */
-                        product_id?: string;
-                        /**
-                         * @description string schema
-                         * @example 2023-10-01
-                         */
+                        /** @example 123e4567-e89b-12d3-a456-426614174000 */
+                        product_id?: string | null;
+                        /** @example 2023-10-01 */
                         released_at?: string | null;
                     }[];
                     /** @example Product Name */
                     name: string;
                     /** @example software */
                     type: string;
-                    /**
-                     * @description string schema
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
-                    vendor_id?: string;
+                    /** @example 123e4567-e89b-12d3-a456-426614174000 */
+                    vendor_id?: string | null;
                     versions?: {
                         /** @example Version Description */
                         description?: string;
@@ -1138,20 +1055,11 @@ export interface components {
                         is_latest: boolean;
                         /** @example Version Name */
                         name: string;
-                        /**
-                         * @description string schema
-                         * @example 123e4567-e89b-12d3-a456-426614174000
-                         */
+                        /** @example 123e4567-e89b-12d3-a456-426614174000 */
                         predecessor_id?: string | null;
-                        /**
-                         * @description string schema
-                         * @example 123e4567-e89b-12d3-a456-426614174000
-                         */
-                        product_id?: string;
-                        /**
-                         * @description string schema
-                         * @example 2023-10-01
-                         */
+                        /** @example 123e4567-e89b-12d3-a456-426614174000 */
+                        product_id?: string | null;
+                        /** @example 2023-10-01 */
                         released_at?: string | null;
                     }[];
                 };
@@ -1169,20 +1077,11 @@ export interface components {
                         is_latest: boolean;
                         /** @example Version Name */
                         name: string;
-                        /**
-                         * @description string schema
-                         * @example 123e4567-e89b-12d3-a456-426614174000
-                         */
+                        /** @example 123e4567-e89b-12d3-a456-426614174000 */
                         predecessor_id?: string | null;
-                        /**
-                         * @description string schema
-                         * @example 123e4567-e89b-12d3-a456-426614174000
-                         */
-                        product_id?: string;
-                        /**
-                         * @description string schema
-                         * @example 2023-10-01
-                         */
+                        /** @example 123e4567-e89b-12d3-a456-426614174000 */
+                        product_id?: string | null;
+                        /** @example 2023-10-01 */
                         released_at?: string | null;
                     };
                 }[];
@@ -1192,74 +1091,41 @@ export interface components {
         UpdateIdentificationHelperDTO: {
             /** @example hashes */
             category?: string;
-            /**
-             * @description string schema
-             * @example {"key":"value"}
-             */
-            metadata?: string;
+            /** @example {"key":"value"} */
+            metadata?: string | null;
             /** @example 123e4567-e89b-12d3-a456-426614174000 */
             product_version_id?: string;
         };
         /** @description UpdateProductDTO schema */
         UpdateProductDTO: {
-            /**
-             * @description string schema
-             * @example Product Description
-             */
-            description?: string;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
+            /** @example Product Description */
+            description?: string | null;
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
             family_id?: string | null;
-            /**
-             * @description string schema
-             * @example Product Name
-             */
-            name?: string;
-            /**
-             * @description string schema
-             * @example software
-             */
-            type?: string;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
-            vendor_id?: string;
+            /** @example Product Name */
+            name?: string | null;
+            /** @example software */
+            type?: string | null;
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
+            vendor_id?: string | null;
         };
         /** @description UpdateProductFamilyDTO schema */
         UpdateProductFamilyDTO: {
             /** @example Family Name */
             name?: string;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
-            parent_id?: string;
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
+            parent_id?: string | null;
         };
         /** @description UpdateProductVersionDTO schema */
         UpdateProductVersionDTO: {
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
             predecessor_id?: string | null;
-            /**
-             * @description string schema
-             * @example 123e4567-e89b-12d3-a456-426614174000
-             */
-            product_id?: string;
-            /**
-             * @description string schema
-             * @example 2023-10-01
-             */
-            release_date?: string;
-            /**
-             * @description string schema
-             * @example Version Name
-             */
-            version?: string;
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
+            product_id?: string | null;
+            /** @example 2023-10-01 */
+            release_date?: string | null;
+            /** @example Version Name */
+            version?: string | null;
         };
         /** @description UpdateRelationshipDTO schema */
         UpdateRelationshipDTO: {
@@ -1273,16 +1139,10 @@ export interface components {
         };
         /** @description UpdateVendorDTO schema */
         UpdateVendorDTO: {
-            /**
-             * @description string schema
-             * @example Vendor Description
-             */
-            description?: string;
-            /**
-             * @description string schema
-             * @example Vendor Name
-             */
-            name?: string;
+            /** @example Vendor Description */
+            description?: string | null;
+            /** @example Vendor Name */
+            name?: string | null;
         };
         /** @description VendorDTO schema */
         VendorDTO: {

--- a/client/src/components/layout/version/CreateEditVersion.tsx
+++ b/client/src/components/layout/version/CreateEditVersion.tsx
@@ -42,7 +42,7 @@ export function useVersionMutation({
   productId,
   version,
 }: {
-  productId?: string
+  productId?: string | null
   version: VersionProps
 }) {
   const { navigate } = useRouter()

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -68,6 +68,14 @@
     "relationship": {
       "label": "Beziehung",
       "label_other": "Beziehungen",
+      "outgoing": {
+        "label": "Ausgehende Beziehung",
+        "label_other": "Ausgehende Beziehungen"
+      },
+      "incoming": {
+        "label": "Eingehende Beziehung",
+        "label_other": "Eingehende Beziehungen"
+      },
       "targetProduct": {
         "empty": "Noch keine Zielprodukte hinzugefügt.",
         "label": "Zielprodukt",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -69,6 +69,14 @@
     "relationship": {
       "label": "Relationship",
       "label_other": "Relationships",
+      "outgoing": {
+        "label": "Outgoing Relationship",
+        "label_other": "Outgoing Relationships"
+      },
+      "incoming": {
+        "label": "Incoming Relationship",
+        "label_other": "Incoming Relationships"
+      },
       "targetProduct": {
         "empty": "No target added yet.",
         "label": "Target Product",

--- a/client/src/routes/Product.tsx
+++ b/client/src/routes/Product.tsx
@@ -17,7 +17,7 @@ import { useParams } from 'react-router-dom'
 import { useVendorQuery } from './Vendor'
 import { DeleteVersion } from './Version'
 
-export function useProductQuery(productId?: string) {
+export function useProductQuery(productId?: string | null) {
   const request = client.useQuery(
     'get',
     '/api/v1/products/{id}',
@@ -41,12 +41,12 @@ export function DeleteProduct({
   product,
   isIconButton,
 }: {
-  product: { name: string; id: string; vendor_id?: string }
+  product: { name: string; id: string; vendor_id?: string | null }
   isIconButton?: boolean
 }) {
   const mutation = client.useMutation('delete', '/api/v1/products/{id}', {
     onSettled: () => {
-      navigate(`/vendors/${product.vendor_id}`, {
+      navigate(`/vendors/${product.vendor_id ?? ''}`, {
         state: {
           shouldRefetch: true,
           message: t('product.delete.success', { name: product.name }),

--- a/client/src/routes/ProductFamilies.tsx
+++ b/client/src/routes/ProductFamilies.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next'
 export interface ProductFamily {
   id: string
   name: string
-  parent_id?: string
+  parent_id?: string | null
   path: string[]
 }
 
@@ -62,7 +62,7 @@ export function useProductFamilyListQuery() {
   }
 }
 
-export function useProductFamilyQuery(id: string) {
+export function useProductFamilyQuery(id?: string | null) {
   const request = client.useQuery(
     'get',
     '/api/v1/product-families/{id}',

--- a/client/src/routes/Products.tsx
+++ b/client/src/routes/Products.tsx
@@ -21,7 +21,7 @@ type VersionDTO = {
   is_latest: boolean
   name: string
   predecessor_id?: string | null
-  product_id?: string
+  product_id?: string | null
   released_at?: string | null
 }
 
@@ -52,7 +52,7 @@ export function ProductItem({
     id: string
     name: string
     description?: string
-    vendor_id?: string
+    vendor_id?: string | null
     type?: string
     versions?: VersionDTO[]
     latest_versions?: VersionDTO[]
@@ -62,7 +62,7 @@ export function ProductItem({
   const { t } = useTranslation()
 
   const handleOnActionClick = (href: string) => {
-    navigateToModal(href, `/vendors/${product.vendor_id}`)
+    navigateToModal(href, `/vendors/${product.vendor_id ?? ''}`)
   }
 
   return (

--- a/client/src/routes/Vendor.tsx
+++ b/client/src/routes/Vendor.tsx
@@ -14,7 +14,7 @@ import { useParams } from 'react-router-dom'
 import { ProductItem, useVendorProductListQuery } from './Products'
 import { VendorProps } from './Vendors'
 
-export function useVendorQuery(vendorId?: string) {
+export function useVendorQuery(vendorId?: string | null) {
   const request = client.useQuery(
     'get',
     '/api/v1/vendors/{id}',

--- a/client/src/routes/Version.tsx
+++ b/client/src/routes/Version.tsx
@@ -16,6 +16,47 @@ import { useParams } from 'react-router-dom'
 import { useProductQuery } from './Product'
 import { useVendorQuery } from './Vendor'
 
+type VersionRelationshipGroup = {
+  category: string
+  products: {
+    product: {
+      id: string
+      full_name: string
+    }
+    version_relationships: {
+      id: string
+      version: {
+        id: string
+        name: string
+      }
+    }[]
+  }[]
+}
+
+type RelationshipQueryRequest = {
+  params: {
+    path: {
+      id: string
+    }
+    query: {
+      direction: 'incoming' | 'outgoing'
+    }
+  }
+}
+
+type RelationshipQueryResult = {
+  data?: VersionRelationshipGroup[]
+  refetch: () => void
+}
+
+type RelationshipQueryClient = {
+  useQuery: (
+    method: 'get',
+    path: '/api/v1/product-versions/{id}/relationships',
+    request: RelationshipQueryRequest,
+  ) => RelationshipQueryResult
+}
+
 export function useVersionQuery(versionId?: string) {
   const request = client.useQuery(
     'get',
@@ -163,11 +204,12 @@ export default function Version({
   const { versionId } = useParams()
   const { t } = useTranslation()
   const { navigateToModal, navigate } = useRouter()
+  const relationshipQueryClient = client as unknown as RelationshipQueryClient
 
   const { data: version } = useVersionQuery(versionId)
   const { data: product } = useProductQuery(version?.product_id)
   const { data: vendor } = useVendorQuery(product?.vendor_id)
-  const relationshipRequest = client.useQuery(
+  const outgoingRelationshipRequest = relationshipQueryClient.useQuery(
     'get',
     `/api/v1/product-versions/{id}/relationships`,
     {
@@ -175,11 +217,117 @@ export default function Version({
         path: {
           id: versionId || '',
         },
+        query: {
+          direction: 'outgoing',
+        },
       },
     },
   )
-  useRefetchQuery(relationshipRequest)
-  const relationships = relationshipRequest.data
+  const incomingRelationshipRequest = relationshipQueryClient.useQuery(
+    'get',
+    `/api/v1/product-versions/{id}/relationships`,
+    {
+      params: {
+        path: {
+          id: versionId || '',
+        },
+        query: {
+          direction: 'incoming',
+        },
+      },
+    },
+  )
+
+  useRefetchQuery(outgoingRelationshipRequest)
+  useRefetchQuery(incomingRelationshipRequest)
+
+  const outgoingRelationships =
+    (outgoingRelationshipRequest.data as
+      | VersionRelationshipGroup[]
+      | undefined) ?? []
+  const incomingRelationships =
+    (incomingRelationshipRequest.data as
+      | VersionRelationshipGroup[]
+      | undefined) ?? []
+
+  const renderRelationshipGroups = ({
+    groups,
+    includeHeaderActions,
+  }: {
+    groups: typeof outgoingRelationships
+    includeHeaderActions?: boolean
+  }) =>
+    groups.map((relationship) => (
+      <ListGroup
+        title={t(`relationship.category.${relationship.category}`)}
+        key={relationship.category}
+        headerActions={
+          includeHeaderActions ? (
+            <div className="flex gap-1">
+              <IconButton
+                icon={faEdit}
+                onPress={() => {
+                  navigateToModal(
+                    `/product-versions/${versionId}/relationships/${relationship.category}/edit`,
+                    `/product-versions/${versionId}`,
+                  )
+                }}
+              />
+
+              <DeleteRelationshipGroup
+                group={relationship}
+                version={{ id: version?.id ?? '' }}
+                onDelete={() => {
+                  outgoingRelationshipRequest.refetch()
+                  incomingRelationshipRequest.refetch()
+                }}
+              />
+            </div>
+          ) : undefined
+        }
+      >
+        {relationship.products
+          .slice()
+          .sort((a, b) =>
+            a.product.full_name.localeCompare(b.product.full_name),
+          )
+          .map((product, index) => (
+            <div
+              key={`${relationship.category}-${product.product.id}`}
+              className={cn(
+                'flex flex-col w-full gap-2 bg-white px-4 py-2 border-1 border-default-200',
+                relationship.products.length - 1 === index
+                  ? 'rounded-b-lg'
+                  : '',
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <div className={cn('text-lg font-semibold')}>
+                    {product.product.full_name}
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex gap-2 pb-1">
+                {product.version_relationships?.map((versionRel) => (
+                  <Chip
+                    key={versionRel.id}
+                    variant="solid"
+                    radius="md"
+                    className="cursor-pointer hover:underline"
+                    onClick={() => {
+                      navigate(`/product-versions/${versionRel.version.id}`)
+                    }}
+                  >
+                    {versionRel.version.name}
+                  </Chip>
+                ))}
+              </div>
+            </div>
+          ))}
+      </ListGroup>
+    ))
 
   if (!version || !product || !vendor) {
     return null
@@ -208,7 +356,7 @@ export default function Version({
 
       <div className="flex w-full flex-col items-center gap-4">
         <DataGrid
-          title={`${t('relationship.label', { count: 2 })}`}
+          title={`${t('relationship.outgoing.label', { count: 2 })}`}
           addButton={
             <AddRelationshipButton
               versionId={version.id}
@@ -216,76 +364,14 @@ export default function Version({
             />
           }
         >
-          {relationships?.map((relationship) => (
-            <ListGroup
-              title={t(`relationship.category.${relationship.category}`)}
-              key={relationship.category}
-              headerActions={
-                <div className="flex gap-1">
-                  <IconButton
-                    icon={faEdit}
-                    onPress={() => {
-                      navigateToModal(
-                        `/product-versions/${versionId}/relationships/${relationship.category}/edit`,
-                        `/product-versions/${versionId}`,
-                      )
-                    }}
-                  />
+          {renderRelationshipGroups({
+            groups: outgoingRelationships,
+            includeHeaderActions: true,
+          })}
+        </DataGrid>
 
-                  <DeleteRelationshipGroup
-                    group={relationship}
-                    version={version}
-                    onDelete={() => {
-                      relationshipRequest.refetch()
-                    }}
-                  />
-                </div>
-              }
-            >
-              {relationship.products
-                .slice()
-                .sort((a, b) =>
-                  a.product.full_name.localeCompare(b.product.full_name),
-                )
-                .map((product, index) => (
-                  <div
-                    key={`${relationship.category}-${product.product.id}`}
-                    className={cn(
-                      'flex flex-col w-full gap-2 bg-white px-4 py-2 border-1 border-default-200',
-                      relationship.products.length - 1 === index
-                        ? 'rounded-b-lg'
-                        : '',
-                    )}
-                  >
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <div className={cn('text-lg font-semibold')}>
-                          {product.product.full_name}
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="flex gap-2 pb-1">
-                      {product.version_relationships?.map((versionRel) => (
-                        <Chip
-                          key={versionRel.id}
-                          variant="solid"
-                          radius="md"
-                          className="cursor-pointer hover:underline"
-                          onClick={() => {
-                            navigate(
-                              `/product-versions/${versionRel.version.id}`,
-                            )
-                          }}
-                        >
-                          {versionRel.version.name}
-                        </Chip>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-            </ListGroup>
-          ))}
+        <DataGrid title={`${t('relationship.incoming.label', { count: 2 })}`}>
+          {renderRelationshipGroups({ groups: incomingRelationships })}
         </DataGrid>
       </div>
     </div>

--- a/client/src/utils/useErrorLocalization.ts
+++ b/client/src/utils/useErrorLocalization.ts
@@ -1,23 +1,25 @@
 interface ErrorMore {
   tag?: string
-  field?: string
+  field?: string | null
 }
 
 interface ErrorItem {
-  name?: string
-  reason?: string
+  name?: string | null
+  reason?: string | null
   more?: ErrorMore | null
 }
 
 interface ErrorObject {
-  errors?: ErrorItem[] | null
+  errors?: (ErrorItem | null)[] | null
 }
 
 export const useErrorLocalization = (error: ErrorObject | null | undefined) => {
   const getErrorByFieldName = (fieldName: string): ErrorItem | undefined => {
     if (!error?.errors) return undefined
 
-    return error.errors.find((err) => err.more?.field == fieldName)
+    return error.errors.find(
+      (err): err is ErrorItem => !!err && err.more?.field == fieldName,
+    )
   }
 
   const isFieldInvalid = (fieldName: string): boolean => {
@@ -29,7 +31,7 @@ export const useErrorLocalization = (error: ErrorObject | null | undefined) => {
     if (!fieldError) return undefined
 
     // Return tag if available, otherwise return the reason
-    return fieldError.more?.tag || fieldError.reason
+    return fieldError.more?.tag || fieldError.reason || undefined
   }
 
   return {

--- a/client/tests/Select.test.tsx
+++ b/client/tests/Select.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Select from '@/components/forms/Select'
+
+const heroSelectMock = vi.fn((props: any) => <div data-testid="hero-select">{props.children}</div>)
+
+vi.mock('@heroui/react', () => ({
+  Select: (props: any) => heroSelectMock(props),
+}))
+
+describe('Select', () => {
+  beforeEach(() => {
+    heroSelectMock.mockClear()
+  })
+
+  it('applies default select props when values are not provided', () => {
+    render(<Select {...({ 'aria-label': 'Select' } as any)} />)
+
+    const passedProps = heroSelectMock.mock.calls[0][0]
+    expect(passedProps.labelPlacement).toBe('outside')
+    expect(passedProps.placeholder).toBe(' ')
+    expect(passedProps.variant).toBe('bordered')
+    expect(passedProps.classNames).toEqual({
+      trigger: 'border-1 shadow-none',
+    })
+  })
+
+  it('uses explicitly provided props and forwards remaining props', () => {
+    const onChange = vi.fn()
+
+    render(
+      <Select
+        {...({
+          'aria-label': 'Select',
+          labelPlacement: 'inside',
+          placeholder: 'Choose one',
+          variant: 'flat',
+          onChange,
+        } as any)}
+      />,
+    )
+
+    const passedProps = heroSelectMock.mock.calls[0][0]
+    expect(passedProps.labelPlacement).toBe('inside')
+    expect(passedProps.placeholder).toBe('Choose one')
+    expect(passedProps.variant).toBe('flat')
+    expect(passedProps.onChange).toBe(onChange)
+  })
+})

--- a/client/tests/Version.comprehensive.test.tsx
+++ b/client/tests/Version.comprehensive.test.tsx
@@ -45,6 +45,8 @@ vi.mock('react-i18next', () => ({
         'product.label': options?.count === 2 ? 'Products' : 'Product',
         'version.label': options?.count === 2 ? 'Versions' : 'Version',
         'relationship.label': options?.count === 2 ? 'Relationships' : 'Relationship',
+        'relationship.outgoing.label': options?.count === 2 ? 'Outgoing Relationships' : 'Outgoing Relationship',
+        'relationship.incoming.label': options?.count === 2 ? 'Incoming Relationships' : 'Incoming Relationship',
         'common.delete': 'Delete',
         'common.confirmDeleteTitle': 'Confirm Delete',
         'common.confirmDeleteText': 'Are you sure you want to delete this {{resource}}?',
@@ -654,6 +656,29 @@ describe('Version Components', () => {
       },
     ]
 
+    const mockIncomingRelationshipsData = [
+      {
+        category: 'depends_on',
+        products: [
+          {
+            product: {
+              id: 'incoming-product-1',
+              full_name: 'Incoming Product',
+            },
+            version_relationships: [
+              {
+                id: 'incoming-rel-1',
+                version: {
+                  id: 'incoming-version-1',
+                  name: '3.0.0',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
     beforeEach(() => {
       // Mock version query
       mockClient.useQuery
@@ -668,6 +693,12 @@ describe('Version Components', () => {
           error: null,
           refetch: vi.fn(),
         })
+        .mockReturnValueOnce({
+          data: mockIncomingRelationshipsData,
+          isLoading: false,
+          error: null,
+          refetch: vi.fn(),
+        })
     })
 
     it('should render with complete data', () => {
@@ -678,10 +709,11 @@ describe('Version Components', () => {
       )
 
       expect(screen.getByTestId('breadcrumbs')).toBeInTheDocument()
-      expect(screen.getByTestId('data-grid')).toBeInTheDocument()
+      expect(screen.getAllByTestId('data-grid')).toHaveLength(2)
       expect(screen.getByTestId('add-relationship-button')).toBeInTheDocument()
       expect(screen.getByText('Related Product A')).toBeInTheDocument()
       expect(screen.getByText('Related Product B')).toBeInTheDocument()
+      expect(screen.getByText('Incoming Product')).toBeInTheDocument()
     })
 
     it('should hide breadcrumbs when hideBreadcrumbs is true', () => {
@@ -692,7 +724,7 @@ describe('Version Components', () => {
       )
 
       expect(screen.queryByTestId('breadcrumbs')).not.toBeInTheDocument()
-      expect(screen.getByTestId('data-grid')).toBeInTheDocument()
+      expect(screen.getAllByTestId('data-grid')).toHaveLength(2)
     })
 
     it('should return null when version data is missing', () => {
@@ -779,6 +811,12 @@ describe('Version Components', () => {
         })
         .mockReturnValueOnce({
           data: mockRelationshipsData,
+          isLoading: false,
+          error: null,
+          refetch: vi.fn(),
+        })
+        .mockReturnValueOnce({
+          data: mockIncomingRelationshipsData,
           isLoading: false,
           error: null,
           refetch: vi.fn(),
@@ -882,7 +920,7 @@ describe('Version Components', () => {
         </TestWrapper>
       )
 
-      const container = screen.getByTestId('data-grid').parentElement?.parentElement
+      const container = screen.getAllByTestId('data-grid')[0].parentElement?.parentElement
       expect(container).toHaveClass('flex', 'w-full', 'grow', 'flex-col', 'gap-4', 'p-2')
     })
 
@@ -913,6 +951,12 @@ describe('Version Components', () => {
         })
         .mockReturnValueOnce({
           data: mockRelationshipsData,
+          isLoading: false,
+          error: null,
+          refetch: vi.fn(),
+        })
+        .mockReturnValueOnce({
+          data: mockIncomingRelationshipsData,
           isLoading: false,
           error: null,
           refetch: vi.fn(),

--- a/server/internal/handler.go
+++ b/server/internal/handler.go
@@ -185,7 +185,29 @@ func (h *Handler) GetProductVersion(c fuego.ContextNoBody) (ProductVersionDTO, e
 
 func (h *Handler) ListRelationshipsByProductVersion(c fuego.ContextNoBody) ([]RelationshipGroupDTO, error) {
 	productVersionID := c.PathParam("id")
-	relationships, err := h.svc.GetRelationshipsByProductVersion(c.Request().Context(), productVersionID)
+	direction := c.Request().URL.Query().Get("direction")
+
+	var (
+		relationships []RelationshipGroupDTO
+		err           error
+	)
+
+	switch direction {
+	case "", "outgoing":
+		relationships, err = h.svc.GetRelationshipsByProductVersion(c.Request().Context(), productVersionID)
+	case "incoming":
+		relationships, err = h.svc.GetIncomingRelationshipsByProductVersion(c.Request().Context(), productVersionID)
+	default:
+		return nil, fuego.BadRequestError{
+			Title: "Invalid relationship direction",
+			Errors: []fuego.ErrorItem{
+				{
+					Name:   "direction",
+					Reason: "Direction must be either 'incoming' or 'outgoing'",
+				},
+			},
+		}
+	}
 
 	if err != nil {
 		return nil, err

--- a/server/internal/handler_test.go
+++ b/server/internal/handler_test.go
@@ -226,6 +226,15 @@ func testRelationshipOperations(t *testing.T, svc *Service, ctx context.Context,
 		t.Error("Expected at least one relationship")
 	}
 
+	// Get incoming relationships by product version (target side)
+	incomingRelationships, err := svc.GetIncomingRelationshipsByProductVersion(ctx, targetVersionID)
+	if err != nil {
+		t.Fatalf("GetIncomingRelationshipsByProductVersion failed: %v", err)
+	}
+	if len(incomingRelationships) == 0 {
+		t.Error("Expected at least one incoming relationship")
+	}
+
 	// Get the first relationship ID
 	var relationshipID string
 	if len(relationships) > 0 && len(relationships[0].Products) > 0 && len(relationships[0].Products[0].VersionRelationships) > 0 {
@@ -961,6 +970,45 @@ func testRelationshipHandlers(t *testing.T, app *fuego.Server) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	// Test ListRelationshipsByProductVersion incoming direction
+	req = httptest.NewRequest(
+		"GET",
+		fmt.Sprintf("/api/v1/product-versions/%s/relationships?direction=incoming", version2.ID),
+		nil,
+	)
+	w = httptest.NewRecorder()
+	app.Mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200 for incoming direction, got %d", w.Code)
+	}
+
+	// Test ListRelationshipsByProductVersion invalid direction
+	req = httptest.NewRequest(
+		"GET",
+		fmt.Sprintf("/api/v1/product-versions/%s/relationships?direction=invalid", version1.ID),
+		nil,
+	)
+	w = httptest.NewRecorder()
+	app.Mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for invalid direction, got %d", w.Code)
+	}
+
+	// Test incoming direction for non-existent version to cover service error path
+	req = httptest.NewRequest(
+		"GET",
+		"/api/v1/product-versions/00000000-0000-0000-0000-000000000000/relationships?direction=incoming",
+		nil,
+	)
+	w = httptest.NewRecorder()
+	app.Mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404 for non-existent incoming direction request, got %d", w.Code)
 	}
 
 	// Parse the response to get relationship ID

--- a/server/internal/repository.go
+++ b/server/internal/repository.go
@@ -69,7 +69,9 @@ func (r *repository) GetNodeByID(ctx context.Context, id string, opts ...LoadOpt
 		query = query.Preload("Children")
 	}
 	if options.LoadRelationships {
-		query = query.Preload("SourceRelationships.TargetNode.Parent.Parent")
+		query = query.
+			Preload("SourceRelationships.TargetNode.Parent.Parent").
+			Preload("TargetRelationships.SourceNode.Parent.Parent")
 	}
 	if options.LoadParent {
 		query = query.Preload("Parent")

--- a/server/internal/service.go
+++ b/server/internal/service.go
@@ -906,7 +906,7 @@ func (s *Service) GetProductVersionByID(ctx context.Context, id string) (Product
 
 // Relationships
 
-func (s *Service) GetRelationshipsByProductVersion(ctx context.Context, versionID string) ([]RelationshipGroupDTO, error) {
+func (s *Service) getVersionWithRelationships(ctx context.Context, versionID string) (Node, error) {
 	version, err := s.repo.GetNodeByID(ctx, versionID, WithRelationships(), WithChildren())
 	notFoundError := fuego.NotFoundError{
 		Title: "Product version not found",
@@ -914,9 +914,9 @@ func (s *Service) GetRelationshipsByProductVersion(ctx context.Context, versionI
 
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, notFoundError
+			return Node{}, notFoundError
 		} else {
-			return nil, fuego.InternalServerError{
+			return Node{}, fuego.InternalServerError{
 				Title: "Failed to fetch product version",
 				Err:   err,
 			}
@@ -924,46 +924,47 @@ func (s *Service) GetRelationshipsByProductVersion(ctx context.Context, versionI
 	}
 
 	if version.Category != ProductVersion {
-		return nil, notFoundError
+		return Node{}, notFoundError
 	}
 
-	// Group by category first, then by product within each category
+	return version, nil
+}
+
+func buildRelationshipGroups(
+	relationships []Relationship,
+	getRelatedVersion func(rel Relationship) *Node,
+) []RelationshipGroupDTO {
 	categoryGroups := make(map[string]map[string]*RelationshipGroupItemDTO)
 
-	for _, rel := range version.SourceRelationships {
-		// We need to make sure the target node and its parent exist
-		if rel.TargetNode == nil || rel.TargetNode.Parent == nil {
+	for _, rel := range relationships {
+		relatedVersion := getRelatedVersion(rel)
+		if relatedVersion == nil || relatedVersion.Parent == nil {
 			continue
 		}
 
 		category := string(rel.Category)
-		productID := rel.TargetNode.Parent.ID
+		productID := relatedVersion.Parent.ID
 
-		// Initialize category map if it doesn't exist
 		if categoryGroups[category] == nil {
 			categoryGroups[category] = make(map[string]*RelationshipGroupItemDTO)
 		}
 
-		// Get or create the product group item
 		if categoryGroups[category][productID] == nil {
 			categoryGroups[category][productID] = &RelationshipGroupItemDTO{
-				Product:              NodeToProductDTO(*rel.TargetNode.Parent),
+				Product:              NodeToProductDTO(*relatedVersion.Parent),
 				VersionRelationships: []ProductionVersionRelationshipDTO{},
 			}
 		}
 
-		// Add the version relationship to the existing product group
-		versionRelationship := ProductionVersionRelationshipDTO{
-			RelationshipID: rel.ID,
-			Version:        NodeToProductVersionDTO(*rel.TargetNode),
-		}
 		categoryGroups[category][productID].VersionRelationships = append(
 			categoryGroups[category][productID].VersionRelationships,
-			versionRelationship,
+			ProductionVersionRelationshipDTO{
+				RelationshipID: rel.ID,
+				Version:        NodeToProductVersionDTO(*relatedVersion),
+			},
 		)
 	}
 
-	// Convert the nested maps to the final result structure
 	var result []RelationshipGroupDTO
 	for category, productGroups := range categoryGroups {
 		var products []RelationshipGroupItemDTO
@@ -977,7 +978,31 @@ func (s *Service) GetRelationshipsByProductVersion(ctx context.Context, versionI
 		})
 	}
 
-	return result, nil
+	return result
+}
+
+func (s *Service) GetRelationshipsByProductVersion(ctx context.Context, versionID string) ([]RelationshipGroupDTO, error) {
+	version, err := s.getVersionWithRelationships(ctx, versionID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buildRelationshipGroups(version.SourceRelationships, func(rel Relationship) *Node {
+		return rel.TargetNode
+	}), nil
+}
+
+func (s *Service) GetIncomingRelationshipsByProductVersion(ctx context.Context, versionID string) ([]RelationshipGroupDTO, error) {
+	version, err := s.getVersionWithRelationships(ctx, versionID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buildRelationshipGroups(version.TargetRelationships, func(rel Relationship) *Node {
+		return rel.SourceNode
+	}), nil
 }
 
 func (s *Service) CreateRelationship(ctx context.Context, create CreateRelationshipDTO) error {


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

This PR introduces bidirectional relationship visibility for product versions.

Previously, relationships were only visible from one side (outgoing).
With this change, users can now see:
- outgoing relationships (editable)
- incoming relationships (read-only)

This makes relationship navigation and analysis much clearer.

Closes #12 