### PR TITLE
feat: ID Helper Validation

### DIFF
--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -118,6 +118,13 @@
       "hashValues": "Hash-Werte",
       "namespace": "Namespace",
       "noDataYet": "Noch keine {{type}} hinzugefügt. Klicken Sie auf \"{{buttonText}}\", um zu beginnen.",
+        "validation": {
+          "invalidCpe": "Bitte geben Sie einen g\u00fcltigen CPE-String ein.",
+          "invalidPurl": "Bitte geben Sie einen g\u00fcltigen PURL-String ein.",
+          "invalidSbomUrl": "Bitte geben Sie g\u00fcltige HTTP/HTTPS-SBOM-URLs ein.",
+          "incompleteUri": "Jede URI-Zeile ben\u00f6tigt sowohl Namespace als auch URI.",
+          "invalidGenericUri": "Bitte geben Sie g\u00fcltige URI-Werte ein (z. B. urn:, mailto: oder https:)."
+        },
       "fields": {
         "cpeString": "CPE-String",
         "purlString": "PURL-String",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -119,6 +119,13 @@
       "hashValues": "Hash Values",
       "namespace": "Namespace",
       "noDataYet": "No {{type}} added yet. Click \"{{buttonText}}\" to get started.",
+      "validation": {
+        "invalidCpe": "Please enter a valid CPE string.",
+        "invalidPurl": "Please enter a valid PURL string.",
+        "invalidSbomUrl": "Please enter valid HTTP/HTTPS SBOM URL(s).",
+        "incompleteUri": "Each URI row requires both namespace and URI.",
+        "invalidGenericUri": "Please enter valid URI values (for example urn:, mailto:, or https:)."
+      },
       "fields": {
         "cpeString": "CPE String",
         "purlString": "PURL String",

--- a/client/src/routes/IdentificationHelper/CreateIDHelper.tsx
+++ b/client/src/routes/IdentificationHelper/CreateIDHelper.tsx
@@ -129,6 +129,179 @@ export function handleTypeSelection(
   }
 }
 
+export function isValidHttpUrl(value: string): boolean {
+  const trimmedValue = value.trim()
+  if (!trimmedValue) return false
+
+  try {
+    const parsed = new URL(trimmedValue)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function isValidGenericUri(value: string): boolean {
+  const trimmedValue = value.trim()
+  if (!trimmedValue) return false
+
+  // RFC 3986-like scheme check. Allows URL and non-URL URIs such as urn: and mailto:.
+  return /^[a-z][a-z0-9+.-]*:[^\s]+$/i.test(trimmedValue)
+}
+
+export function isValidPurlString(value: string): boolean {
+  const trimmedValue = value.trim()
+  if (!trimmedValue) return false
+
+  // purl spec shape: pkg:type/name@version?qualifiers#subpath
+  return /^pkg:[a-z0-9.+-]+\/[^\s@?#]+(?:\/[^\s@?#]+)*(?:@[^\s?#]+)?(?:\?[^\s#]+)?(?:#\S+)?$/i.test(
+    trimmedValue,
+  )
+}
+
+export function isValidCpeString(value: string): boolean {
+  const trimmedValue = value.trim()
+  if (!trimmedValue) return false
+
+  // CPE 2.3: cpe:2.3:part:vendor:product:version:update:edition:language:sw_edition:target_sw:target_hw:other
+  if (trimmedValue.startsWith('cpe:2.3:')) {
+    const parts = trimmedValue.split(':')
+    if (parts.length !== 13) return false
+    if (!['a', 'o', 'h', '*'].includes(parts[2])) return false
+    return parts.slice(3).every((part) => part.length > 0)
+  }
+
+  // CPE 2.2 URI binding (kept for compatibility): cpe:/part:vendor:product:...
+  return /^cpe:\/[aho*](?::[^\s:]*){0,6}$/i.test(trimmedValue)
+}
+
+export function isValidIdentificationHelperData(
+  selectedType: HelperTypeProps | null,
+  helperData: HelperData | null,
+): boolean {
+  if (!selectedType || !helperData) return false
+
+  switch (selectedType.component) {
+    case 'cpe': {
+      const cpe = (helperData as CPEData).cpe || ''
+      return isValidCpeString(cpe)
+    }
+    case 'purl': {
+      const purl = (helperData as PURLData).purl || ''
+      return isValidPurlString(purl)
+    }
+    case 'hashes': {
+      const hashData = helperData as HashData
+      return hashData.file_hashes.some(
+        (fh) =>
+          fh.filename?.trim() &&
+          fh.items.some((item) => item.algorithm?.trim() && item.value?.trim()),
+      )
+    }
+    case 'models':
+      return (helperData as ModelData).models.some((m) => m?.trim())
+    case 'sbom': {
+      const sbomUrls = (helperData as SBOMData).sbom_urls
+      const trimmed = sbomUrls.map((url) => url?.trim() || '')
+      const nonEmpty = trimmed.filter(Boolean)
+      return nonEmpty.length > 0 && nonEmpty.every((url) => isValidHttpUrl(url))
+    }
+    case 'serial':
+      return (helperData as SerialData).serial_numbers.some((sn) => sn?.trim())
+    case 'sku':
+      return (helperData as SKUData).skus.some((sku) => sku?.trim())
+    case 'uri': {
+      const uris = (helperData as URIData).uris
+      if (!uris.length) return false
+
+      const completedUris = uris.filter(
+        (uri) => uri.namespace?.trim() && uri.uri?.trim(),
+      )
+      if (!completedUris.length) return false
+
+      // All rows must be complete and valid to avoid persisting partial URI entries.
+      return (
+        completedUris.length === uris.length &&
+        completedUris.every((uri) => isValidGenericUri(uri.uri))
+      )
+    }
+    default:
+      return false
+  }
+}
+
+export function hasEnteredIdentificationHelperData(
+  selectedType: HelperTypeProps | null,
+  helperData: HelperData | null,
+): boolean {
+  if (!selectedType || !helperData) return false
+
+  switch (selectedType.component) {
+    case 'cpe':
+      return !!(helperData as CPEData).cpe?.trim()
+    case 'purl':
+      return !!(helperData as PURLData).purl?.trim()
+    case 'hashes': {
+      const hashData = helperData as HashData
+      return hashData.file_hashes.some(
+        (fh) =>
+          !!fh.filename?.trim() ||
+          fh.items.some(
+            (item) => !!item.algorithm?.trim() || !!item.value?.trim(),
+          ),
+      )
+    }
+    case 'models':
+      return (helperData as ModelData).models.some((m) => !!m?.trim())
+    case 'sbom':
+      return (helperData as SBOMData).sbom_urls.some((url) => !!url?.trim())
+    case 'serial':
+      return (helperData as SerialData).serial_numbers.some(
+        (sn) => !!sn?.trim(),
+      )
+    case 'sku':
+      return (helperData as SKUData).skus.some((sku) => !!sku?.trim())
+    case 'uri':
+      return (helperData as URIData).uris.some(
+        (uri) => !!uri.namespace?.trim() || !!uri.uri?.trim(),
+      )
+    default:
+      return false
+  }
+}
+
+export function getIdentificationHelperValidationError(
+  selectedType: HelperTypeProps | null,
+  helperData: HelperData | null,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string | null {
+  if (!selectedType || !helperData) return null
+  if (!hasEnteredIdentificationHelperData(selectedType, helperData)) return null
+  if (isValidIdentificationHelperData(selectedType, helperData)) return null
+
+  switch (selectedType.component) {
+    case 'cpe':
+      return t('identificationHelper.validation.invalidCpe')
+    case 'purl':
+      return t('identificationHelper.validation.invalidPurl')
+    case 'sbom':
+      return t('identificationHelper.validation.invalidSbomUrl')
+    case 'uri': {
+      const uris = (helperData as URIData).uris
+      const hasIncompleteRow = uris.some((uri) => {
+        const hasAnyValue = !!uri.namespace?.trim() || !!uri.uri?.trim()
+        const isComplete = !!uri.namespace?.trim() && !!uri.uri?.trim()
+        return hasAnyValue && !isComplete
+      })
+      return hasIncompleteRow
+        ? t('identificationHelper.validation.incompleteUri')
+        : t('identificationHelper.validation.invalidGenericUri')
+    }
+    default:
+      return t('form.errors')
+  }
+}
+
 // Component for CPE input
 function CPEComponent({
   data,
@@ -764,41 +937,12 @@ export default function CreateEditIDHelper({
   }
 
   const canSubmit = useMemo(() => {
-    if (!selectedType || !helperData) return false
-
-    // Basic validation for different types
-    switch (selectedType.component) {
-      case 'cpe':
-        return !!(helperData as CPEData).cpe?.trim()
-      case 'purl':
-        return !!(helperData as PURLData).purl?.trim()
-      case 'hashes':
-        const hashData = helperData as HashData
-        return hashData.file_hashes.some(
-          (fh) =>
-            fh.filename?.trim() &&
-            fh.items.some(
-              (item) => item.algorithm?.trim() && item.value?.trim(),
-            ),
-        )
-      case 'models':
-        return (helperData as ModelData).models.some((m) => m?.trim())
-      case 'sbom':
-        return (helperData as SBOMData).sbom_urls.some((url) => url?.trim())
-      case 'serial':
-        return (helperData as SerialData).serial_numbers.some((sn) =>
-          sn?.trim(),
-        )
-      case 'sku':
-        return (helperData as SKUData).skus.some((sku) => sku?.trim())
-      case 'uri':
-        return (helperData as URIData).uris.some(
-          (uri) => uri.namespace?.trim() && uri.uri?.trim(),
-        )
-      default:
-        return false
-    }
+    return isValidIdentificationHelperData(selectedType, helperData)
   }, [selectedType, helperData])
+
+  const validationErrorMessage = useMemo(() => {
+    return getIdentificationHelperValidationError(selectedType, helperData, t)
+  }, [selectedType, helperData, t])
 
   const handleSubmit = () => {
     if (!selectedType || !helperData || !canSubmit || !versionId) return
@@ -903,6 +1047,15 @@ export default function CreateEditIDHelper({
                     data={helperData}
                     onChange={setHelperData}
                   />
+                )}
+
+                {validationErrorMessage && (
+                  <p
+                    className="text-sm text-danger"
+                    data-testid="id-helper-validation-error"
+                  >
+                    {validationErrorMessage}
+                  </p>
                 )}
               </div>
             )}

--- a/client/src/routes/IdentificationHelper/IdentificationOverview.tsx
+++ b/client/src/routes/IdentificationHelper/IdentificationOverview.tsx
@@ -164,7 +164,7 @@ function IdentificationItem({
   return (
     <div className="group flex w-full flex-col justify-between gap-2 rounded-lg border-1 border-default-200 bg-gray-50 px-4 py-2 hover:bg-gray-100 hover:transition-background">
       <div className="flex items-center justify-between">
-        <div className="flex grow flex-col gap-1">
+        <div className="flex grow flex-col gap-1 min-w-0">
           <div>
             <div className="text-sm text-default-500">
               {t(`${helperType.translationKey}.label`)}

--- a/client/tests/CreateIDHelper.test.tsx
+++ b/client/tests/CreateIDHelper.test.tsx
@@ -391,7 +391,7 @@ describe('CreateIDHelper', () => {
         data: { 
           id: 'test-helper-id',
           category: 'cpe',
-          metadata: JSON.stringify({ cpe: 'test-cpe' })
+          metadata: JSON.stringify({ cpe: 'cpe:2.3:a:test:product:1.0:*:*:*:*:*:*:*' })
         },
         isLoading: false,
         error: null,
@@ -1188,6 +1188,34 @@ describe('CreateIDHelper', () => {
   })
 
   describe('Validation Logic', () => {
+    it('should show validation text when CPE is invalid', () => {
+      const editData = {
+        type: idHelperTypes[0], // CPE
+        helperId: 'test-cpe-invalid-id',
+      }
+
+      mockClient.useQuery.mockReturnValue({
+        data: {
+          id: 'test-cpe-invalid-id',
+          category: 'cpe',
+          metadata: JSON.stringify({ cpe: 'cpe:2.3:a:vendor:product' }),
+        },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+
+      render(
+        <TestWrapper>
+          <CreateIDHelper editData={editData} onClose={mockOnClose} />
+        </TestWrapper>
+      )
+
+      expect(screen.getByTestId('id-helper-validation-error')).toHaveTextContent(
+        'identificationHelper.validation.invalidCpe',
+      )
+    })
+
     it('should validate CPE helper correctly', () => {
       const editData = {
         type: idHelperTypes[0], // CPE
@@ -1426,7 +1454,7 @@ describe('CreateIDHelper', () => {
         data: { 
           id: 'test-id',
           category: 'cpe',
-          metadata: JSON.stringify({ cpe: 'test-cpe' })
+          metadata: JSON.stringify({ cpe: 'cpe:2.3:a:test:product:1.0:*:*:*:*:*:*:*' })
         },
         isLoading: false,
         error: null,
@@ -2254,7 +2282,7 @@ describe('CreateIDHelper', () => {
         data: { 
           id: 'test-submit-id',
           category: 'cpe',
-          metadata: JSON.stringify({ cpe: 'valid-cpe-string' })
+          metadata: JSON.stringify({ cpe: 'cpe:2.3:a:test:product:1.0:*:*:*:*:*:*:*' })
         },
         isLoading: false,
         error: null,
@@ -2274,7 +2302,7 @@ describe('CreateIDHelper', () => {
       expect(mockMutate).toHaveBeenCalledWith({
         params: { path: { id: 'test-submit-id' } },
         body: {
-          metadata: JSON.stringify({ cpe: 'valid-cpe-string' }),
+          metadata: JSON.stringify({ cpe: 'cpe:2.3:a:test:product:1.0:*:*:*:*:*:*:*' }),
         },
       })
     })
@@ -2529,7 +2557,7 @@ describe('CreateIDHelper', () => {
       const testCases = [
         {
           type: idHelperTypes.find(t => t.id === 'cpe')!,
-          metadata: { cpe: 'valid-cpe-string' },
+          metadata: { cpe: 'cpe:2.3:a:test:product:1.0:*:*:*:*:*:*:*' },
           shouldBeValid: true
         },
         {

--- a/client/tests/CreateIDHelper.validation.test.ts
+++ b/client/tests/CreateIDHelper.validation.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getIdentificationHelperValidationError,
+  hasEnteredIdentificationHelperData,
+  isValidCpeString,
+  isValidGenericUri,
+  isValidHttpUrl,
+  isValidIdentificationHelperData,
+  isValidPurlString,
+} from '@/routes/IdentificationHelper/CreateIDHelper'
+import { idHelperTypes } from '@/routes/IdentificationHelper/IdentificationOverview'
+
+describe('CreateIDHelper validation utilities', () => {
+  const mockT = (key: string) => key
+
+  it('validates HTTP/HTTPS URLs', () => {
+    expect(isValidHttpUrl('https://example.com/sbom.json')).toBe(true)
+    expect(isValidHttpUrl('http://example.com')).toBe(true)
+    expect(isValidHttpUrl('ftp://example.com')).toBe(false)
+    expect(isValidHttpUrl('not-a-url')).toBe(false)
+  })
+
+  it('validates generic URIs', () => {
+    expect(isValidGenericUri('urn:uuid:123e4567-e89b-12d3-a456-426614174000')).toBe(
+      true,
+    )
+    expect(isValidGenericUri('mailto:security@example.com')).toBe(true)
+    expect(isValidGenericUri('https://example.com/resource')).toBe(true)
+    expect(isValidGenericUri('example.com/resource')).toBe(false)
+  })
+
+  it('validates purl strings', () => {
+    expect(isValidPurlString('pkg:npm/lodash@4.17.21')).toBe(true)
+    expect(
+      isValidPurlString('pkg:maven/org.apache.commons/commons-lang3@3.14.0'),
+    ).toBe(true)
+    expect(isValidPurlString('pkg:/missing-type')).toBe(false)
+    expect(isValidPurlString('lodash@4.17.21')).toBe(false)
+  })
+
+  it('validates cpe strings', () => {
+    expect(
+      isValidCpeString('cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*'),
+    ).toBe(true)
+    expect(isValidCpeString('cpe:/a:vendor:product:1.0')).toBe(true)
+    expect(isValidCpeString('cpe:2.3:a:vendor:product')).toBe(false)
+    expect(isValidCpeString('invalid-cpe')).toBe(false)
+  })
+
+  it('validates SBOM URLs using helper data validation', () => {
+    const sbomType = idHelperTypes.find((t) => t.id === 'sbom')
+    expect(sbomType).toBeTruthy()
+
+    expect(
+      isValidIdentificationHelperData(sbomType!, {
+        sbom_urls: ['https://example.com/sbom.json'],
+      }),
+    ).toBe(true)
+
+    expect(
+      isValidIdentificationHelperData(sbomType!, {
+        sbom_urls: ['https://example.com/sbom.json', 'invalid-url'],
+      }),
+    ).toBe(false)
+  })
+
+  it('validates generic URI helper rows are complete and valid', () => {
+    const uriType = idHelperTypes.find((t) => t.id === 'uri')
+    expect(uriType).toBeTruthy()
+
+    expect(
+      isValidIdentificationHelperData(uriType!, {
+        uris: [{ namespace: 'prod', uri: 'urn:uuid:123e4567-e89b-12d3-a456-426614174000' }],
+      }),
+    ).toBe(true)
+
+    expect(
+      isValidIdentificationHelperData(uriType!, {
+        uris: [{ namespace: 'prod', uri: '' }],
+      }),
+    ).toBe(false)
+
+    expect(
+      isValidIdentificationHelperData(uriType!, {
+        uris: [
+          { namespace: 'prod', uri: 'urn:uuid:123e4567-e89b-12d3-a456-426614174000' },
+          { namespace: '', uri: 'https://example.com/resource' },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  it('validates CPE helper data through unified validation', () => {
+    const cpeType = idHelperTypes.find((t) => t.id === 'cpe')
+    expect(cpeType).toBeTruthy()
+
+    expect(
+      isValidIdentificationHelperData(cpeType!, {
+        cpe: 'cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*',
+      }),
+    ).toBe(true)
+
+    expect(
+      isValidIdentificationHelperData(cpeType!, {
+        cpe: 'cpe:2.3:a:vendor:product',
+      }),
+    ).toBe(false)
+  })
+
+  it('detects whether user has entered helper data', () => {
+    const cpeType = idHelperTypes.find((t) => t.id === 'cpe')
+    expect(cpeType).toBeTruthy()
+
+    expect(
+      hasEnteredIdentificationHelperData(cpeType!, {
+        cpe: '',
+      }),
+    ).toBe(false)
+
+    expect(
+      hasEnteredIdentificationHelperData(cpeType!, {
+        cpe: 'cpe:2.3:a:vendor:product',
+      }),
+    ).toBe(true)
+  })
+
+  it('returns validation message for invalid CPE after data entry', () => {
+    const cpeType = idHelperTypes.find((t) => t.id === 'cpe')
+    expect(cpeType).toBeTruthy()
+
+    expect(
+      getIdentificationHelperValidationError(
+        cpeType!,
+        { cpe: 'cpe:2.3:a:vendor:product' },
+        mockT,
+      ),
+    ).toBe('identificationHelper.validation.invalidCpe')
+  })
+
+  it('does not return validation message when no value was entered', () => {
+    const purlType = idHelperTypes.find((t) => t.id === 'purl')
+    expect(purlType).toBeTruthy()
+
+    expect(
+      getIdentificationHelperValidationError(purlType!, { purl: '' }, mockT),
+    ).toBeNull()
+  })
+
+  it('returns URI-specific validation message for incomplete rows', () => {
+    const uriType = idHelperTypes.find((t) => t.id === 'uri')
+    expect(uriType).toBeTruthy()
+
+    expect(
+      getIdentificationHelperValidationError(
+        uriType!,
+        { uris: [{ namespace: 'prod', uri: '' }] },
+        mockT,
+      ),
+    ).toBe('identificationHelper.validation.incompleteUri')
+  })
+})


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

This change introduces stricter, type-specific validation for ID Helper entries and improves user feedback when input is invalid, specifically for SBOM, CPE, PURL, URL.

1. Open Add/Edit Identification Helper.
2. For each type (CPE, PURL, SBOM, URI), first leave empty: no error shown, submit disabled.
3. Enter invalid value:
SBOM: example.com or ftp://...
CPE: cpe:2.3:a:vendor:product
PURL: lodash@4.17.21
URI: namespace filled but URI empty, or URI example.com
Expected: validation error appears and submit stays disabled.
4. Replace with valid value:
SBOM: https://example.com/sbom.json
CPE: cpe:2.3:o:microsoft:windows_vista:6.0:sp1:-:-:home_premium:-:x64:-
PURL: pkg:npm/lodash@4.17.21
URI: Namespace: product, URI: urn:uuid:123e4567-e89b-12d3-a456-426614174000
Expected: error disappears and submit is enabled.
5. Switch EN/DE and re-check one invalid case: error text should be localized.

## Related Tickets & Documents

- Closes #21 
